### PR TITLE
Check for rosemont and verdun pages

### DIFF
--- a/dist/index-en.html
+++ b/dist/index-en.html
@@ -113,10 +113,10 @@
       "areaServed": ["Montreal", "Rosemont", "Verdun", "Quebec"],
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "3507 rue Masson",
+        "streetAddress": "3036 Masson St",
         "addressLocality": "Montreal",
         "addressRegion": "QC",
-        "postalCode": "H1X 1R5",
+        "postalCode": "H1Y 1X6",
         "addressCountry": "CA"
       },
       "department": [
@@ -129,10 +129,10 @@
           "servesCuisine": ["Burgers", "Premium Homemade", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "3507 rue Masson",
+            "streetAddress": "3036 Masson St",
             "addressLocality": "Montreal",
             "addressRegion": "QC",
-            "postalCode": "H1X 1R5",
+            "postalCode": "H1Y 1X6",
             "addressCountry": "CA"
           },
           "geo": {
@@ -150,7 +150,7 @@
           "servesCuisine": ["Burgers", "Premium Homemade", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "4557 rue Wellington",
+            "streetAddress": "4567 Wellington St",
             "addressLocality": "Montreal",
             "addressRegion": "QC",
             "postalCode": "H4G 1W8",

--- a/dist/index.html
+++ b/dist/index.html
@@ -69,10 +69,10 @@
       "areaServed": ["Montréal", "Rosemont", "Verdun", "Québec"],
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "3507 rue Masson",
+        "streetAddress": "3036 rue Masson",
         "addressLocality": "Montréal",
         "addressRegion": "QC",
-        "postalCode": "H1X 1R5",
+        "postalCode": "H1Y 1X6",
         "addressCountry": "CA"
       },
       "department": [
@@ -85,10 +85,10 @@
           "servesCuisine": ["Burgers", "Premium Faits Maison", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "3507 rue Masson",
+            "streetAddress": "3036 rue Masson",
             "addressLocality": "Montréal",
             "addressRegion": "QC",
-            "postalCode": "H1X 1R5",
+            "postalCode": "H1Y 1X6",
             "addressCountry": "CA"
           },
           "geo": {
@@ -106,7 +106,7 @@
           "servesCuisine": ["Burgers", "Premium Faits Maison", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "4557 rue Wellington",
+            "streetAddress": "4567 rue Wellington",
             "addressLocality": "Montréal",
             "addressRegion": "QC",
             "postalCode": "H4G 1W8",

--- a/index-en.html
+++ b/index-en.html
@@ -265,10 +265,10 @@
       "areaServed": ["Montreal", "Rosemont", "Verdun", "Quebec"],
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "3507 rue Masson",
+        "streetAddress": "3036 Masson St",
         "addressLocality": "Montreal",
         "addressRegion": "QC",
-        "postalCode": "H1X 1R5",
+        "postalCode": "H1Y 1X6",
         "addressCountry": "CA"
       },
       "department": [
@@ -281,10 +281,10 @@
           "servesCuisine": ["Burgers", "Premium Homemade", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "3507 rue Masson",
+            "streetAddress": "3036 Masson St",
             "addressLocality": "Montreal",
             "addressRegion": "QC",
-            "postalCode": "H1X 1R5",
+            "postalCode": "H1Y 1X6",
             "addressCountry": "CA"
           },
           "geo": {
@@ -302,7 +302,7 @@
           "servesCuisine": ["Burgers", "Premium Homemade", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "4557 rue Wellington",
+            "streetAddress": "4567 Wellington St",
             "addressLocality": "Montreal",
             "addressRegion": "QC",
             "postalCode": "H4G 1W8",

--- a/index-fr.html
+++ b/index-fr.html
@@ -69,10 +69,10 @@
       "areaServed": ["Montréal", "Rosemont", "Verdun", "Québec"],
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "3507 rue Masson",
+        "streetAddress": "3036 rue Masson",
         "addressLocality": "Montréal",
         "addressRegion": "QC",
-        "postalCode": "H1X 1R5",
+        "postalCode": "H1Y 1X6",
         "addressCountry": "CA"
       },
       "department": [
@@ -85,10 +85,10 @@
           "servesCuisine": ["Burgers", "Premium Faits Maison", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "3507 rue Masson",
+            "streetAddress": "3036 rue Masson",
             "addressLocality": "Montréal",
             "addressRegion": "QC",
-            "postalCode": "H1X 1R5",
+            "postalCode": "H1Y 1X6",
             "addressCountry": "CA"
           },
           "geo": {
@@ -106,7 +106,7 @@
           "servesCuisine": ["Burgers", "Premium Faits Maison", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "4557 rue Wellington",
+            "streetAddress": "4567 rue Wellington",
             "addressLocality": "Montréal",
             "addressRegion": "QC",
             "postalCode": "H4G 1W8",

--- a/index.html
+++ b/index.html
@@ -69,10 +69,10 @@
       "areaServed": ["Montréal", "Rosemont", "Verdun", "Québec"],
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "3507 rue Masson",
+        "streetAddress": "3036 Masson St",
         "addressLocality": "Montréal",
         "addressRegion": "QC",
-        "postalCode": "H1X 1R5",
+        "postalCode": "H1Y 1X6",
         "addressCountry": "CA"
       },
       "department": [
@@ -85,10 +85,10 @@
           "servesCuisine": ["Burgers", "Premium Faits Maison", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "3507 rue Masson",
+            "streetAddress": "3036 Masson St",
             "addressLocality": "Montréal",
             "addressRegion": "QC",
-            "postalCode": "H1X 1R5",
+            "postalCode": "H1Y 1X6",
             "addressCountry": "CA"
           },
           "geo": {
@@ -106,7 +106,7 @@
           "servesCuisine": ["Burgers", "Premium Faits Maison", "Smash Burgers"],
           "address": {
             "@type": "PostalAddress",
-            "streetAddress": "4557 rue Wellington",
+            "streetAddress": "4567 rue Wellington",
             "addressLocality": "Montréal",
             "addressRegion": "QC",
             "postalCode": "H4G 1W8",

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@ JOYO Burger is Montreal's premier destination for premium homemade smash burgers
 - **Industry**: Restaurant / Food Service / Premium Fast Casual
 - **Cuisine**: Smash Burgers, Halal Food, Hand-Cut Fries, Craft Beverages
 - **Locations**: 
-  - 3507 rue Masson, Montréal, QC H1X 1R5
-  - 4557 rue Wellington, Montréal, QC H4G 1W8
+  - 3036 rue Masson, Montréal, QC H1Y 1X6
+  - 4567 rue Wellington, Montréal, QC H4G 1W8
 - **Phone**: +1 (514) 508-5696
 - **Website**: https://www.joyoburger.com
 - **Languages**: French (Primary), English


### PR DESCRIPTION
Correct inconsistent addresses for Rosemont and Verdun locations to ensure accurate map links and location information.

The homepage schema data and `llms.txt` contained incorrect street numbers and postal codes for both Rosemont (3507 Masson St instead of 3036 Masson St) and Verdun (4557 Wellington St instead of 4567 Wellington St). This led to Google Maps links directing users to the wrong locations, including an address in Ontario for Rosemont. This PR synchronizes all address references with the correct information found in the dedicated location pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c9b4000-cf03-41ce-95e2-5341782ba8c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c9b4000-cf03-41ce-95e2-5341782ba8c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed incorrect addresses for Rosemont and Verdun so map links and search show the right locations. Aligns homepage structured data with the official location pages.

- **Bug Fixes**
  - Rosemont updated to 3036 Masson St, Montreal, QC H1Y 1X6 (was 3507 / H1X 1R5).
  - Verdun updated to 4567 Wellington St, Montreal, QC H4G 1W8 (was 4557).
  - Corrected JSON-LD in index.html, index-en.html, index-fr.html and their dist builds.
  - Synced llms.txt with the same addresses.

<!-- End of auto-generated description by cubic. -->

