### PR TITLE
Remove anniversary banner from Verdun/Wellington pages

### DIFF
--- a/dist/verdun-wellington-fr.html
+++ b/dist/verdun-wellington-fr.html
@@ -271,6 +271,12 @@
             color: var(--ochre);
             font-size: 12px;
         }
+
+          /* Retired Verdun anniversary promo banner */
+          .promo-top-banner,
+          #promo-banner {
+              display: none !important;
+          }
     </style>
     
     <!-- Gallery Section Styles -->
@@ -2344,5 +2350,37 @@
             });
         });
     </script>
+
+      <!-- Ensure legacy Verdun promo banners stay removed -->
+      <script>
+          document.addEventListener('DOMContentLoaded', function() {
+              var path = window.location ? window.location.pathname : '';
+              if (!path || path.indexOf('verdun-wellington') === -1) return;
+              
+              var selectors = ['#promo-banner', '.promo-top-banner'];
+              selectors.forEach(function(selector) {
+                  document.querySelectorAll(selector).forEach(function(node) {
+                      if (node && node.parentNode) {
+                          node.parentNode.removeChild(node);
+                      }
+                  });
+              });
+              
+              document.querySelectorAll('a[href*="digicpn.com/p/cara9q/ryzdihmqxvuckmfyaj3p5"]').forEach(function(link) {
+                  var container = link.closest('.promo-top-banner');
+                  if (container && container.parentNode) {
+                      container.parentNode.removeChild(container);
+                  } else {
+                      link.remove();
+                  }
+              });
+              
+              try {
+                  localStorage.removeItem('promoBannerClosed');
+              } catch (err) {
+                  console.warn('Promo banner cleanup issue:', err);
+              }
+          });
+      </script>
 </body>
 </html>

--- a/dist/verdun-wellington.html
+++ b/dist/verdun-wellington.html
@@ -271,6 +271,12 @@
             color: var(--ochre);
             font-size: 12px;
         }
+
+          /* Retired Verdun anniversary promo banner */
+          .promo-top-banner,
+          #promo-banner {
+              display: none !important;
+          }
     </style>
     
     <!-- Gallery Section Styles -->
@@ -2345,5 +2351,37 @@
             });
         });
     </script>
+
+      <!-- Ensure legacy Verdun promo banners stay removed -->
+      <script>
+          document.addEventListener('DOMContentLoaded', function() {
+              var path = window.location ? window.location.pathname : '';
+              if (!path || path.indexOf('verdun-wellington') === -1) return;
+              
+              var selectors = ['#promo-banner', '.promo-top-banner'];
+              selectors.forEach(function(selector) {
+                  document.querySelectorAll(selector).forEach(function(node) {
+                      if (node && node.parentNode) {
+                          node.parentNode.removeChild(node);
+                      }
+                  });
+              });
+              
+              document.querySelectorAll('a[href*="digicpn.com/p/cara9q/ryzdihmqxvuckmfyaj3p5"]').forEach(function(link) {
+                  var container = link.closest('.promo-top-banner');
+                  if (container && container.parentNode) {
+                      container.parentNode.removeChild(container);
+                  } else {
+                      link.remove();
+                  }
+              });
+              
+              try {
+                  localStorage.removeItem('promoBannerClosed');
+              } catch (err) {
+                  console.warn('Promo banner cleanup issue:', err);
+              }
+          });
+      </script>
 </body>
 </html>

--- a/verdun-wellington-fr.html
+++ b/verdun-wellington-fr.html
@@ -271,6 +271,12 @@
             color: var(--ochre);
             font-size: 12px;
         }
+
+          /* Retired Verdun anniversary promo banner */
+          .promo-top-banner,
+          #promo-banner {
+              display: none !important;
+          }
     </style>
     
     <!-- Gallery Section Styles -->
@@ -2344,5 +2350,37 @@
             });
         });
     </script>
+
+      <!-- Ensure legacy Verdun promo banners stay removed -->
+      <script>
+          document.addEventListener('DOMContentLoaded', function() {
+              var path = window.location ? window.location.pathname : '';
+              if (!path || path.indexOf('verdun-wellington') === -1) return;
+              
+              var selectors = ['#promo-banner', '.promo-top-banner'];
+              selectors.forEach(function(selector) {
+                  document.querySelectorAll(selector).forEach(function(node) {
+                      if (node && node.parentNode) {
+                          node.parentNode.removeChild(node);
+                      }
+                  });
+              });
+              
+              document.querySelectorAll('a[href*="digicpn.com/p/cara9q/ryzdihmqxvuckmfyaj3p5"]').forEach(function(link) {
+                  var container = link.closest('.promo-top-banner');
+                  if (container && container.parentNode) {
+                      container.parentNode.removeChild(container);
+                  } else {
+                      link.remove();
+                  }
+              });
+              
+              try {
+                  localStorage.removeItem('promoBannerClosed');
+              } catch (err) {
+                  console.warn('Promo banner cleanup issue:', err);
+              }
+          });
+      </script>
 </body>
 </html>

--- a/verdun-wellington.html
+++ b/verdun-wellington.html
@@ -271,6 +271,12 @@
             color: var(--ochre);
             font-size: 12px;
         }
+
+          /* Retired Verdun anniversary promo banner */
+          .promo-top-banner,
+          #promo-banner {
+              display: none !important;
+          }
     </style>
     
     <!-- Gallery Section Styles -->
@@ -2345,5 +2351,37 @@
             });
         });
     </script>
+
+      <!-- Ensure legacy Verdun promo banners stay removed -->
+      <script>
+          document.addEventListener('DOMContentLoaded', function() {
+              var path = window.location ? window.location.pathname : '';
+              if (!path || path.indexOf('verdun-wellington') === -1) return;
+              
+              var selectors = ['#promo-banner', '.promo-top-banner'];
+              selectors.forEach(function(selector) {
+                  document.querySelectorAll(selector).forEach(function(node) {
+                      if (node && node.parentNode) {
+                          node.parentNode.removeChild(node);
+                      }
+                  });
+              });
+              
+              document.querySelectorAll('a[href*="digicpn.com/p/cara9q/ryzdihmqxvuckmfyaj3p5"]').forEach(function(link) {
+                  var container = link.closest('.promo-top-banner');
+                  if (container && container.parentNode) {
+                      container.parentNode.removeChild(container);
+                  } else {
+                      link.remove();
+                  }
+              });
+              
+              try {
+                  localStorage.removeItem('promoBannerClosed');
+              } catch (err) {
+                  console.warn('Promo banner cleanup issue:', err);
+              }
+          });
+      </script>
 </body>
 </html>


### PR DESCRIPTION
Remove the Verdun/Wellington anniversary banner and add defensive measures to prevent its reappearance.

The banner was a temporary anniversary promotion. This PR ensures its complete removal, including any potential re-injections from GTM or older builds, and clears related local storage flags.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9570d12-b6b0-4224-8c74-7585acb630de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9570d12-b6b0-4224-8c74-7585acb630de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the retired Verdun anniversary banner from the Verdun/Wellington pages and added safeguards so it can’t come back. Prevents reinjection from legacy sources and clears old promo state.

- **Bug Fixes**
  - Hide and remove .promo-top-banner and #promo-banner via CSS and DOM cleanup.
  - Strip legacy Digicpn promo links and clear promoBannerClosed in localStorage.
  - Scoped to Verdun/Wellington pages (EN and FR).

<sup>Written for commit b0a21dc7083021dd11397700adebcdf86a659931. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

